### PR TITLE
feat: reactive ui

### DIFF
--- a/src/ui/MessagesView/MessagesView.jsx
+++ b/src/ui/MessagesView/MessagesView.jsx
@@ -42,11 +42,26 @@ const MessagesView = () => {
     send: 0, // the unit is bytes/s
     receive: 0,
   });
+  const [isCompact, setIsCompact] = useState(false);
 
   const timer = useRef(null);
+  const statbarRef = useRef(null);
   const gridRef = useRef(null);
   const servicesRef = useRef(new Set()); // we need ref to get old values in all renders
   const methodsRef = useRef(new Set());
+
+  const setCompactMode = () => {
+    if (statbarRef.current.offsetWidth < 600) {
+      setIsCompact(true);
+    } else {
+      setIsCompact(false);
+    }
+  };
+
+  useEffect(() => {
+    setCompactMode();
+    window.addEventListener('resize', setCompactMode);
+  }, []);
 
   // run if autoScroll or bottomRow changes
   useEffect(() => {
@@ -203,36 +218,36 @@ const MessagesView = () => {
 
   return (
     <div>
-      <div className="statbar">
+      <div ref={statbarRef} className="statbar">
         <div className="toolbar">
           <button
             className={`toolbar-button ${capturing ? 'active' : ''}`}
             onClick={toggleCapturing}
           >
             <span className="toolbar-icon icon-record"></span>
-            Capture
+            {isCompact ? null : <span className="toolbar-text">Capture</span>}
           </button>
           <button className="toolbar-button" onClick={clearMessages}>
             <span className="toolbar-icon icon-clear"></span>
-            Clear
+            {isCompact ? null : <span className="toolbar-text">Clear</span>}
           </button>
           <button
             className={`toolbar-button ${autoScroll ? 'active' : ''}`}
             onClick={toggleAutoScroll}
           >
             <span className="toolbar-icon icon-bottom"></span>
-            Scroll
+            {isCompact ? null : <span className="toolbar-text">Scroll</span>}
           </button>
           <button
             className={`toolbar-button ${filters.enabled ? 'active' : ''}`}
             onClick={toggleFilters}
           >
             <span className="toolbar-icon icon-filter"></span>
-            Filters
+            {isCompact ? null : <span className="toolbar-text">Filters</span>}
           </button>
           <button className="toolbar-button" onClick={clearFilters}>
             <span className="toolbar-icon icon-reset"></span>
-            Reset Filters
+            {isCompact ? null : <span className="toolbar-text">Reset Filters</span>}
           </button>
           <button
             className={`toolbar-button ${
@@ -241,7 +256,7 @@ const MessagesView = () => {
             onClick={toggleShouldParseExtProtocol}
           >
             <span className="toolbar-icon icon-braces"></span>
-            Parse ExtProtocol
+            {isCompact ? null : <span className="toolbar-text">Parse ExtProtocol</span>}
           </button>
         </div>
         <div className="netbar">

--- a/src/ui/MessagesView/MessagesView.scss
+++ b/src/ui/MessagesView/MessagesView.scss
@@ -23,6 +23,7 @@
 }
 
 .toolbar-button {
+  flex-shrink: 0;
   -webkit-font-smoothing: antialiased;
   background-color: #e1ecf4;
   border-radius: 3px;
@@ -32,18 +33,16 @@
   color: #39739d;
   cursor: pointer;
   display: inline-block;
-  // font-family: -apple-system, system-ui, 'Segoe UI', 'Liberation Sans',
-  //   sans-serif;
   font-size: 12px;
   font-weight: 400;
   line-height: 1.15385;
   margin: 0;
   outline: none;
-  // padding: 8px 0.8em;
   position: relative;
   text-align: center;
   text-decoration: none;
   -webkit-user-select: none;
+  user-select: none;
   touch-action: manipulation;
   vertical-align: baseline;
   white-space: nowrap;
@@ -60,10 +59,13 @@
   color: #2c5777;
 }
 
+.toolbar-text {
+  margin-left: 5px;
+}
+
 .toolbar-icon {
   width: 13px;
   height: 13px;
-  margin-right: 5px;
   float: left;
 }
 

--- a/src/ui/MessagesView/ResizableTable.jsx
+++ b/src/ui/MessagesView/ResizableTable.jsx
@@ -8,6 +8,18 @@ const ResizableTable = ({ children }) => {
   const ref1 = useRef(null);
   const ref2 = useRef(null);
 
+  const arrangeColumns = (col1Width, col2Width) => {
+    if (col2Width < 150) {
+      col2Width = 150;
+      col1Width = tableElement.current.offsetWidth - col2Width;
+    }
+    if (col1Width < 50) {
+      col1Width = 50;
+      col2Width = tableElement.current.offsetWidth - col1Width;
+    }
+    tableElement.current.style.gridTemplateColumns = `${col1Width}px ${col2Width}px`;
+  };
+
   useEffect(() => {
     setTableHeight(tableElement.current.offsetHeight);
   }, []);
@@ -17,10 +29,9 @@ const ResizableTable = ({ children }) => {
   };
 
   const mouseMove = useCallback((e) => {
-    const col1Width = e.clientX - ref1.current.offsetLeft;
-    const col2Width =
-      ref1.current.offsetWidth + ref2.current.offsetWidth - col1Width;
-    tableElement.current.style.gridTemplateColumns = `${col1Width}px ${col2Width}px`;
+    let col1Width = e.clientX - ref1.current.offsetLeft;
+    let col2Width = tableElement.current.offsetWidth - col1Width;
+    arrangeColumns(col1Width, col2Width);
   }, []);
 
   const removeListeners = useCallback(() => {
@@ -43,6 +54,20 @@ const ResizableTable = ({ children }) => {
       removeListeners();
     };
   }, [handleStatus, mouseMove, mouseUp, removeListeners]);
+
+  const onResize = useCallback(() => {
+    const col1Width = ref1.current.offsetWidth;
+    const col2Width = ref2.current.offsetWidth;
+    const tableWidth = tableElement.current.offsetWidth;
+    let newCol1Width = (col1Width / (col1Width + col2Width)) * tableWidth;
+    let newCol2Width = tableWidth - newCol1Width;
+
+    arrangeColumns(newCol1Width, newCol2Width);
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('resize', onResize);
+  }, [onResize]);
 
   return (
     <table className="rt-table" ref={tableElement}>

--- a/src/ui/MessagesView/ResizableTable.scss
+++ b/src/ui/MessagesView/ResizableTable.scss
@@ -6,7 +6,7 @@ table.rt-table {
   display: grid;
   overflow: auto;
   grid-template-columns:
-    minmax(150px, 7fr)
+    minmax(50px, 7fr)
     minmax(150px, 3fr);
 
   overflow: hidden;


### PR DESCRIPTION
resolve #30 
resolve #31

https://user-images.githubusercontent.com/32434520/184924068-7c88980b-0a6c-4132-9808-456d9b16921c.mov

有一个瑕疵，可以不理会：

不同的浏览器对resize事件的处理方式不一样，chrome是连续触发两次onResize。于是第一次resize时，若到了右边界，则取col2Wdith为150px，于是紧接着的第二次onRsize时，输入的col2Width就是150px了，导致最终的结果不是期待的等比例缩放。

对于非触碰边界的情况，则可以保持等比例。因为两次onResize的输入都一样。